### PR TITLE
Fix truthiness of 'limit=0'

### DIFF
--- a/huntlib/splunk.py
+++ b/huntlib/splunk.py
@@ -105,7 +105,7 @@ class SplunkDF(object):
                     end_time = end_time.isoformat()
                 search_args["latest_time"] = end_time
 
-        if limit != None:
+        if limit is not None:
             search_args['count'] = limit
             # use the "oneshot" job type, since it will accept the 'count'
             # argument. Downside is that it's subject to a max result set

--- a/huntlib/splunk.py
+++ b/huntlib/splunk.py
@@ -105,7 +105,7 @@ class SplunkDF(object):
                     end_time = end_time.isoformat()
                 search_args["latest_time"] = end_time
 
-        if limit:
+        if limit != None:
             search_args['count'] = limit
             # use the "oneshot" job type, since it will accept the 'count'
             # argument. Downside is that it's subject to a max result set


### PR DESCRIPTION
If `limit` (and thereby `count`) is passed as 0, this returns an unlimited result set that does use the oneshot job.

This resolves #4 