### PR TITLE
Multiprocessing support for SplunkDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,27 @@ df = s.search_df(
 ```
 In the event you need more control over which "internal" fields to drop, you can pass a comma-separated list of field names (NOTE: these can be any field, not just Splunk internal fields).
 
+Splunk's Python API can be quite slow, so to speed things up you may elect to spread the result retrieval among multiple cores.  The default is to use one (1) extra core, but you can use the `processes` argument to `search()` or `search_df()` to set this higher if you like.  
+
+```python
+df = s.search_df(
+    spl="search index=win_events EventCode=4688", 
+    processes=4
+)
+```
+
+If you prefer to use all your cores, try something like:
+
+```python
+from multiprocessing import cpu_count
+
+df = s.search_df(
+    spl="search index=win_events EventCode=4688",
+    processes=cpu_count()
+)
+```
+
+*NOTE: You may have to experiment to find the optimal number of parallel processes for your specific environment. Maxing out the number of workers doesn't always give the best performance.*
 
 ## Data Module
 

--- a/huntlib/__init__.py
+++ b/huntlib/__init__.py
@@ -8,6 +8,8 @@ import getpass
 import math
 from jellyfish import levenshtein_distance, damerau_levenshtein_distance, hamming_distance, jaro_similarity, jaro_winkler_similarity
 import sys
+import platform
+import multiprocessing
 
 __all__ = ['entropy', 'entropy_per_byte', 'promptCreds', 'edit_distance']
 
@@ -92,3 +94,13 @@ def edit_distance(str1, str2, method="damerau-levenshtein"):
         str2 = unicode(str2)
 
     return distance_function(str1, str2)
+
+
+# First time initialization on import
+
+# Set Mac OS systems to use the older "fork" method of spawning 
+# procs for the multiprocessing module.  For some reason the newer
+# methods don't work (EOFErrors when creating Manager() objects)
+system_type = platform.system()
+if system_type == "Darwin":
+    multiprocessing.set_start_method('fork')

--- a/huntlib/elastic.py
+++ b/huntlib/elastic.py
@@ -89,7 +89,8 @@ class ElasticDF(object):
 
     def search(self, lucene, index="*", doctype="doc", fields=None,
                date_field="@timestamp", days=None, start_time=None,
-               end_time=None, limit=None, processes=1, page_size=1000):
+               end_time=None, limit=None, processes=1, page_size=1000, 
+               scroll_window="10m"):
         '''
         Search Elastic and return the results as a list of dicts.
 
@@ -139,7 +140,7 @@ class ElasticDF(object):
 
         # Set up scrolling if we're using multiprocessing
         if processes > 1:
-            s = s.params(scroll="10m")
+            s = s.params(scroll=scroll_window)
 
         # Add a search limit, if one is specified. Note that this is per-shard,
         # not total results.  Since this is where the search actually runs (the
@@ -199,7 +200,7 @@ class ElasticDF(object):
     def search_df(self, lucene, index="*", doctype="doc", fields=None,
                   date_field="@timestamp", days=None, start_time=None,
                   end_time=None, normalize=True, limit=None, processes=1,
-                  page_size=1000):
+                  page_size=1000, scroll_window="10m"):
         '''
         Search Elastic and return the results as a Pandas DataFrame.
 
@@ -230,7 +231,8 @@ class ElasticDF(object):
         for hit in self.search(lucene=lucene, index=index, doctype=doctype,
                                fields=fields, date_field=date_field, days=days,
                                start_time=start_time, end_time=end_time,
-                               limit=limit, processes=processes, page_size=page_size):
+                               limit=limit, processes=processes, page_size=page_size,
+                               scroll_window=scroll_window):
             results.append(hit)
 
         if normalize:

--- a/huntlib/elastic.py
+++ b/huntlib/elastic.py
@@ -1,4 +1,4 @@
-from huntlib.exceptions import *
+from huntlib.exceptions import AuthenticationErrorSearchException, InvalidRequestSearchException, UnknownSearchException
 from builtins import object
 from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search

--- a/huntlib/elastic.py
+++ b/huntlib/elastic.py
@@ -6,13 +6,6 @@ import elasticsearch.exceptions
 import pandas as pd
 from datetime import datetime, timedelta
 
-import multiprocessing
-from multiprocessing import Pool, Manager, Queue, Process
-
-import uuid
-
-from sys import stderr
-
 class ElasticDF(object):
     '''
     The ElasticDF() class searches Elastic and returns results as a Pandas
@@ -73,24 +66,9 @@ class ElasticDF(object):
             http_auth=(username, password)
         )
 
-    def _search_parallel_worker(self, s, processes, slice_queue, search_results):
-
-        if not slice_queue.empty():
-            slice_id = slice_queue.get()
-            s = s.extra(
-                    slice={
-                        "id": slice_id,
-                        "max": processes
-                    }
-                )
-
-            for res in s.scan():
-                search_results.append(res)
-
     def search(self, lucene, index="*", doctype="doc", fields=None,
                date_field="@timestamp", days=None, start_time=None,
-               end_time=None, limit=None, processes=1, page_size=1000, 
-               scroll_window="10m"):
+               end_time=None, limit=None):
         '''
         Search Elastic and return the results as a list of dicts.
 
@@ -138,10 +116,6 @@ class ElasticDF(object):
         elif start_time and end_time:
             s = s.filter('range', ** {date_field: {"gte": start_time, "lte": end_time}})
 
-        # Set up scrolling if we're using multiprocessing
-        if processes > 1:
-            s = s.params(scroll=scroll_window)
-
         # Add a search limit, if one is specified. Note that this is per-shard,
         # not total results.  Since this is where the search actually runs (the
         # call to excute() does this) then we also have to handle authentication
@@ -153,43 +127,13 @@ class ElasticDF(object):
             else:
                 # Scan to explicitly return all results
                 response = s.execute()
+                s = s.scan()
         except elasticsearch.exceptions.AuthenticationException:
             raise AuthenticationErrorSearchException("Login failed.")
 
         if response.success():
-
-            if processes > 1:
-                manager = Manager()
-                search_results = manager.list()
-
-                slice_queue = Queue()
-                for slice_id in list(range(processes)):
-                    slice_queue.put(slice_id)
-
-                workers = list()
-
-                for _ in range(processes):
-                    p = Process(
-                        target=self._search_parallel_worker,
-                        args=(
-                            s,
-                            processes,
-                            slice_queue,
-                            search_results
-                        )
-                    )
-
-                    workers.append(p)
-                    p.start()
-
-                for p in workers:
-                    p.join()
-
-                for res in search_results:
-                    yield res.to_dict()
-            else:
-                for hit in s.scan():
-                    yield hit.to_dict()
+            for hit in s:
+                yield hit.to_dict()
         else:
             reason = response._shards.failures[0].reason
             if "Result window is too large" in reason['reason']:
@@ -199,8 +143,7 @@ class ElasticDF(object):
 
     def search_df(self, lucene, index="*", doctype="doc", fields=None,
                   date_field="@timestamp", days=None, start_time=None,
-                  end_time=None, normalize=True, limit=None, processes=1,
-                  page_size=1000, scroll_window="10m"):
+                  end_time=None, normalize=True, limit=None):
         '''
         Search Elastic and return the results as a Pandas DataFrame.
 
@@ -231,8 +174,7 @@ class ElasticDF(object):
         for hit in self.search(lucene=lucene, index=index, doctype=doctype,
                                fields=fields, date_field=date_field, days=days,
                                start_time=start_time, end_time=end_time,
-                               limit=limit, processes=processes, page_size=page_size,
-                               scroll_window=scroll_window):
+                               limit=limit):
             results.append(hit)
 
         if normalize:

--- a/huntlib/splunk.py
+++ b/huntlib/splunk.py
@@ -188,7 +188,8 @@ class SplunkDF(object):
                 search_args["latest_time"] = end_time
 
         if processes:
-            search_args['max_count'] = limit
+            if limit:
+                search_args['max_count'] = limit
             for res in self._search_parallel(spl, search_args):
                 yield res
         else:

--- a/huntlib/splunk.py
+++ b/huntlib/splunk.py
@@ -127,10 +127,25 @@ class SplunkDF(object):
 
         return list(search_results)
 
+    def _process_result(self, result, **kwargs):
+        if isinstance(result, results.Message):
+            if kwargs['verbose']:
+                print(f"Message: {result}")
+            return None
 
-    def search(self, spl, mode="normal", search_args=None, verbose=False,
-               days=None, start_time=None, end_time=None, limit=None,
-               fields="*", internal_fields=False, processes=1, page_size=1000):
+        if isinstance(result, dict):
+            # Remove internal fields if requested
+            if kwargs['internal_fields'] is False:
+                for field in [key for key in result.keys() if key.startswith('_')]:
+                    result.pop(field)
+            elif isinstance(kwargs['internal_fields'], str):
+                for field in list(map(lambda x: x.strip(), kwargs['internal_fields'].split(','))):
+                    result.pop(field)
+
+        return result
+
+
+    def search(self, *args, **kwargs):
         '''
         Search Splunk and return the results as a list of dicts.
 
@@ -161,108 +176,119 @@ class SplunkDF(object):
                 from the results. Default is False.
         '''
 
-        if fields:
-            spl += f"| fields {fields}"
+        # Valid argument checking
+        valid_args = [
+            'spl', 
+            'mode', 
+            'search_args', 
+            'verbose', 
+            'days', 
+            'start_time',
+            'end_time', 
+            'limit',
+            'fields',
+            'internal_fields',
+            'processes',
+            'page_size'
+        ]
+        for arg in kwargs.keys():
+            if not arg in valid_args:
+                raise TypeError(f"search() got an unexpected keyword argument '{arg}'")
 
-        if not search_args or not isinstance(search_args, dict):
-            search_args = dict()
-        search_args["search_mode"] = mode
+        # Make sure args contain what we think they should
 
-        if days:
+        # Set default values, but only if they don't already exist
+        kwargs['mode'] = kwargs.get('mode', 'normal')
+        kwargs['search_args'] = kwargs.get('search_args', None)
+        kwargs['verbose'] = kwargs.get('verbose', False)
+        kwargs['days'] = kwargs.get('days', None)
+        kwargs['start_time'] = kwargs.get('start_time', None)
+        kwargs['end_time'] = kwargs.get('end_time', None)
+        kwargs['limit'] = kwargs.get('limit', None)
+        kwargs['fields'] = kwargs.get('fields', '*')
+        kwargs['internal_fields'] = kwargs.get('internal_fields', False)
+        kwargs['processes'] = kwargs.get('processes', 1)
+        kwargs['page_size'] = kwargs.get('page_size', 1000)
+
+        # SPL query can be either the first positional argument or the 'spl' keyword arg
+        spl = None
+        if len(args) > 0:
+            spl = args[0]
+        elif "spl" in kwargs:
+            spl = kwargs['spl']
+
+        if spl is None:
+            raise ValueError("You must specify an SPL search string.")
+
+        # If present, internal_fields must be either bool or str
+        if not (isinstance(kwargs['internal_fields'], bool) or isinstance(kwargs['internal_fields'], str)):
+            raise ValueError(f"internal_fields must be a boolean or a string, not {type(kwargs['internal_fields'])}.")
+
+        spl += f"| fields {kwargs['fields']}"
+
+        if not kwargs['search_args'] or not isinstance(kwargs['search_args'], dict):
+            kwargs['search_args'] = dict()
+        kwargs['search_args']["search_mode"] = kwargs['mode']
+
+        if kwargs['days']:
             # Search from current time backwards
-            search_args["earliest_time"] = "-%dd" % days
+            kwargs['search_args']["earliest_time"] = "-%dd" % kwargs['days']
         else:
-            if start_time:
+            if kwargs['start_time']:
                 # convert to string if it's a datetime
-                if isinstance(start_time, datetime):
-                    start_time = start_time.isoformat()
-                search_args["earliest_time"] = start_time
-            if end_time:
+                if isinstance(kwargs['start_time'], datetime):
+                    kwargs['start_time'] = kwargs['start_time'].isoformat()
+                kwargs['search_args']["earliest_time"] = kwargs['start_time']
+            if kwargs['end_time']:
                 # convert to string if it's a datetime
-                if isinstance(end_time, datetime):
-                    end_time = end_time.isoformat()
-                search_args["latest_time"] = end_time
+                if isinstance(kwargs['end_time'], datetime):
+                    kwargs['end_time'] = kwargs['end_time'].isoformat()
+                kwargs['search_args']["latest_time"] = kwargs['end_time']
 
-        if limit:
+        if kwargs['limit']:
 
-            search_args['exec_mode'] = 'blocking'
-            search_args['search_mode'] = 'normal'
-            search_args['max_count'] = limit
+            kwargs['search_args']['exec_mode'] = 'blocking'
+            kwargs['search_args']['search_mode'] = 'normal'
+            kwargs['search_args']['max_count'] = kwargs['limit']
 
             job = self.splunk_conn.jobs.create(
                 spl,
-                **search_args
+                **kwargs['search_args']
             )
 
             for res in self._retrieve_parallel(job):
-                yield res
+                res = self._process_result(res, **kwargs)
+                if res is not None:      
+                    yield res
         else:
-            search_results = self.splunk_conn.jobs.export(spl, **search_args)
+            search_results = self.splunk_conn.jobs.export(
+                spl, 
+                **kwargs['search_args']
+            )
 
             reader = results.ResultsReader(search_results)
 
             for res in reader:
-                if isinstance(res, dict):
-                    # Remove internal fields if requested
-                    if internal_fields is True:
-                        pass
-                    elif internal_fields is False:
-                        for field in [key for key in res.keys() if key.startswith('_')]:
-                            res.pop(field)
-                    elif isinstance(internal_fields, str):
-                        for field in list(map(lambda x: x.strip(), internal_fields.split(','))):
-                            res.pop(field)
-                    else:
-                        raise ValueError(f"internal_fields must be a boolean or a string, not {type(internal_fields)}.")
-                    yield res
-                elif isinstance(res, results.Message) and verbose:
-                    print(f"Message: {res}")
+                    res = self._process_result(res, **kwargs)
+                    if res is not None:
+                        yield res
 
-    def search_df(self, spl, mode="normal", search_args=None, verbose=False,
-                  days=None, start_time=None, end_time=None, normalize=True,
-                  limit=None, fields="*", internal_fields=False, processes=1,
-                  page_size=1000):
+#    def search_df(self, spl, mode="normal", search_args=None, verbose=False,
+#                  days=None, start_time=None, end_time=None, normalize=True,
+#                  limit=None, fields="*", internal_fields=False, processes=1,
+#                  page_size=1000):
+
+    def search_df(self, *args, **kwargs):
         '''
         Search Splunk and return the results as a Pandas DataFrame.
 
-        spl: A string containing the Splunk search in SPL form
-        mode: A string specifying the type of Splunk search to run ("normal" or "realtime")
-        search_args: A dict containing any additional search parameters to pass to
-              the Splunk server.
-        days: Search the past X days. If provided, this supercedes both start_time
-              and end_time.
-        start_time: A datetime() object representing the start of the search
-                    window, or a string in Splunk syntax (e.g., "-2d@d"). If used
-                    without end_time, the end of the search window is the current time.
-        end_time: A datetime() object representing the end of the search window, or a
-                  string in Splunk syntax (e.g., "-2d@d"). If used without start_time,
-                  the search start will be the earliest timestamp in Splunk.
-        verbose: If True, any errors, warnings or other messages encountered
-                 by the search process will be printed to stdout.  The default is False
-                 (suppress these messages).
-        normalize: If set to True, fields containing structures (i.e. subfields)
-                   will be flattened such that each field has it's own column in
-                   the dataframe. If False, there will be a single column for the
-                   structure, with a JSON string encoding all the contents.
-        limit: An integer describing the max number of search results to return.
-        fields: A comma-separated string listing all of the fields to be returned in
-                the results. If not 'None', this is appended to the end of the 'spl'
-                query, like so: "| fields field1,field2,field3".  The default is '*',
-                meaning all fields.
-        internal_fields: Control whether or not to return Splunk's internal fields.
-                If set to False, all fields with names beginning with an underscore 
-                will be removed from the results.  If set to True, nothing will be removed.
-                If this is a string, treat it as a comma-separated list of fields to remove
-                from the results. Default is False.
+        Accepts all the same arguments as the search() function
         '''
 
+        normalize = kwargs.get('normalize', True)
+
         results = list()
-        for hit in self.search(spl=spl, mode=mode,
-                               search_args=search_args, verbose=verbose,
-                               days=days, start_time=start_time,
-                               end_time=end_time, limit=limit,
-                               fields=fields, internal_fields=internal_fields, 
-                               processes=processes, page_size=page_size):
+        for hit in self.search(*args, **kwargs):
             results.append(hit)
 
         if normalize:

--- a/huntlib/splunk.py
+++ b/huntlib/splunk.py
@@ -15,7 +15,7 @@ import splunklib.client as client
 import splunklib.results as results
 import splunklib.binding
 
-from huntlib.exceptions import *
+from huntlib.exceptions import AuthenticationErrorSearchException
 
 
 class SplunkDF(object):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='huntlib',
-      version='0.4.1',
+      version='0.4.5',
       description='A Python library to help with some common threat hunting data analysis operations',
       long_description=long_description,
       long_description_content_type="text/markdown",

--- a/support/certificates/instances.yml
+++ b/support/certificates/instances.yml
@@ -3,6 +3,7 @@ instances:
     dns: 
       - elastic_test 
       - localhost
+      - host.docker.internal
     ip:
       - 127.0.0.1
 

--- a/tests/test_elastic_df.py
+++ b/tests/test_elastic_df.py
@@ -114,28 +114,3 @@ class TestElasticDF(TestCase):
             3,
             "There should be exactly 3 search results with min <= 2"
         )
-
-    def test_basic_search_df_parallel(self):
-        '''
-        Do the most basic search we can (all events in the index over all
-        time).  Then make sure we got the number of events we think we should
-        have and that all data columns are present. 
-        This version returns results as a pandas DataFrame().
-        '''
-        df = self._es_conn.search_df(
-            lucene="*",
-            index="testdata",
-            processes=2
-        )
-
-        self.assertEqual(
-            df.shape[0],
-            5,
-            "There should be exactly 5 search results."
-        )
-
-        for col in ['min', 'max', 'label', 'ts']:
-            self.assertTrue(
-                col in df.columns,
-                f"Column '{col}' was not found in the search results.'"
-            )

--- a/tests/test_elastic_df.py
+++ b/tests/test_elastic_df.py
@@ -114,3 +114,28 @@ class TestElasticDF(TestCase):
             3,
             "There should be exactly 3 search results with min <= 2"
         )
+
+    def test_basic_search_df_parallel(self):
+        '''
+        Do the most basic search we can (all events in the index over all
+        time).  Then make sure we got the number of events we think we should
+        have and that all data columns are present. 
+        This version returns results as a pandas DataFrame().
+        '''
+        df = self._es_conn.search_df(
+            lucene="*",
+            index="testdata",
+            processes=2
+        )
+
+        self.assertEqual(
+            df.shape[0],
+            5,
+            "There should be exactly 5 search results."
+        )
+
+        for col in ['min', 'max', 'label', 'ts']:
+            self.assertTrue(
+                col in df.columns,
+                f"Column '{col}' was not found in the search results.'"
+            )

--- a/tests/test_multi_reads.py
+++ b/tests/test_multi_reads.py
@@ -11,8 +11,8 @@ class TestMultiReads(TestCase):
         (rows, cols) = df.shape
 
         self.assertEqual(cols, 6, "The resulting DataFrame had the wrong number of columns.")
-        self.assertEqual(rows, 1000015, "The resulting DataFrame had the wrong number of rows.")
-        self.assertEqual(df.index.nunique(), 1000015, "DataFrame index values are not unique.")
+        self.assertEqual(rows, 3000015, "The resulting DataFrame had the wrong number of rows.")
+        self.assertEqual(df.index.nunique(), 3000015, "DataFrame index values are not unique.")
 
     def test_read_csv(self):
         df = huntlib.data.read_csv("support/*.csv")

--- a/tests/test_multi_reads.py
+++ b/tests/test_multi_reads.py
@@ -10,9 +10,9 @@ class TestMultiReads(TestCase):
         df = huntlib.data.read_json("support/*.json", lines=True)
         (rows, cols) = df.shape
 
-        self.assertEqual(cols, 5, "The resulting DataFrame had the wrong number of columns.")
-        self.assertEqual(rows, 15, "The resulting DataFrame had the wrong number of rows.")
-        self.assertEqual(df.index.nunique(), 15, "DataFrame index values are not unique.")
+        self.assertEqual(cols, 6, "The resulting DataFrame had the wrong number of columns.")
+        self.assertEqual(rows, 1000015, "The resulting DataFrame had the wrong number of rows.")
+        self.assertEqual(df.index.nunique(), 1000015, "DataFrame index values are not unique.")
 
     def test_read_csv(self):
         df = huntlib.data.read_csv("support/*.csv")

--- a/tests/test_splunk_df.py
+++ b/tests/test_splunk_df.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 
-from huntlib.splunk import SplunkDF
-
+import os
+import unittest
+from multiprocessing import cpu_count
 from unittest import TestCase
 
-from multiprocessing import cpu_count
+from huntlib.splunk import SplunkDF
+
 
 class TestSplunkDF(TestCase):
     _splunk_host = "localhost"
@@ -191,3 +193,28 @@ class TestSplunkDF(TestCase):
                 col in df.columns,
                 f"Column '{col}' was not found in the search results.'"
             )
+
+    @unittest.skipUnless("HUNTLIB_TEST_EXTENDED" in os.environ, "Skipping test_large_search() because it takes a long time...")
+    def test_large_search_df(self):
+        '''
+        Do a basic search that should return a lot of rows.  This requires
+        you to have loaded the "bigdata" index with data.
+
+        We skip this by default because it takes a very long time, but you can
+        re-enable it by setting the HUNTLIB_TEST_EXTENDED environment variable.
+        '''
+        df = self._splunk_conn.search_df(
+            spl="search index=bigdata",
+            fields='val'
+        )
+
+        self.assertEqual(
+            df.shape[0],
+            1000000,
+            "Wrong number of search results."
+        )
+
+        self.assertTrue(
+            "val" in df.columns,
+            "Column 'val' was not found in the search results."
+        )

--- a/tests/test_splunk_df.py
+++ b/tests/test_splunk_df.py
@@ -218,3 +218,29 @@ class TestSplunkDF(TestCase):
             "val" in df.columns,
             "Column 'val' was not found in the search results."
         )
+
+    @unittest.skipUnless("HUNTLIB_TEST_EXTENDED" in os.environ, "Skipping test_large_search() because it takes a long time...")
+    def test_large_search_df_parallel(self):
+        '''
+        Do a basic search that should return a lot of rows.  This requires
+        you to have loaded the "bigdata" index with data.
+
+        We skip this by default because it takes a very long time, but you can
+        re-enable it by setting the HUNTLIB_TEST_EXTENDED environment variable.
+        '''
+        df = self._splunk_conn.search_df(
+            spl="search index=bigdata",
+            fields='val',
+            processes=cpu_count()
+        )
+
+        self.assertEqual(
+            df.shape[0],
+            1000000,
+            "Wrong number of search results."
+        )
+
+        self.assertTrue(
+            "val" in df.columns,
+            "Column 'val' was not found in the search results."
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ envlist =
 [testenv]
 deps =
     pytest
+passenv =
+    HUNTLIB_*
     
 whitelist_externals = 
     echo

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,8 @@ commands_pre =
     echo "****** Loading Elastic data ******"
     bash -c 'docker exec elastic_test bin/elasticsearch-setup-passwords auto --batch --url https://localhost:9200 | grep "PASSWORD elastic" | cut -d" " -f 4 > /tmp/elastic_pass.txt' 
     bash -c 'echo \{\"password\": \"testpass\"\} | curl -u elastic:`cat /tmp/elastic_pass.txt` --cacert support/certs/ca/ca.crt -H "Content-Type: application/json" -XPOST https://localhost:9200/_security/user/elastic/_password  --data-binary @-'
-    bash -c 'curl -u elastic:testpass --cacert support/certs/ca/ca.crt -H "Content-Type: application/json" -XPOST "https://localhost:9200/_bulk?pretty" --data-binary @support/test-data-elastic.json'
+    bash -c 'curl -u elastic:testpass --cacert support/certs/ca/ca.crt -H "Content-Type: application/json" -XPOST "https://localhost:9200/_bulk" --data-binary @support/test-data-elastic.json > /dev/null'
+    bash -c 'curl -u elastic:testpass --cacert support/certs/ca/ca.crt -H "Content-Type: application/json" -XPOST "https://localhost:9200/_bulk" --data-binary @support/test-data-large-elastic.json > /dev/null'
 
     echo "****** Sleeping again to allow time for indexing ******"
     sleep 20

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,7 @@ envlist =
 [testenv]
 deps =
     pytest
-passenv =
-    HUNTLIB_*
+passenv = HUNTLIB_TEST_EXTENDED
     
 whitelist_externals = 
     echo

--- a/tox.ini
+++ b/tox.ini
@@ -32,14 +32,19 @@ commands_pre =
     bash -c 'docker run -it --name create_elastic_certs -e CERTS_DIR=/usr/share/elasticsearch/config/certificates -v `pwd`/support/certs:/certs -v `pwd`/support/certificates:/usr/share/elasticsearch/config/certificates docker.elastic.co/elasticsearch/elasticsearch:7.6.2 bash -c "yum install -y -q -e 0 unzip; ls -la /certs ; ls -la /usr/share/elasticsearch/config/certificates ;if [[ ! -f /certs/bundle.zip ]]; then bin/elasticsearch-certutil cert --silent --pem --in config/certificates/instances.yml -out /certs/bundle.zip; unzip /certs/bundle.zip -d /certs; fi; chown -R 1000:0 /certs"'
 
     echo "****** Starting Splunk Enterprise via Docker ******"
-    bash -c 'docker run -it -d --name splunk_test -e SPLUNK_START_ARGS=--accept-license -e SPLUNK_LICENSE_URI=/tmp/splunk.lic -e SPLUNK_PASSWORD=testpass -p 8000:8000 -p 8089:8089 -v `pwd`/support/Splunk.License:/tmp/splunk.lic -v `pwd`/support/test-data.json:/tmp/test-data.json splunk/splunk:latest'
+    bash -c 'docker run -it -d --name splunk_test -e SPLUNK_START_ARGS=--accept-license -e SPLUNK_LICENSE_URI=/tmp/splunk.lic -e SPLUNK_PASSWORD=testpass -p 8000:8000 -p 8089:8089 -v `pwd`/support/Splunk.License:/tmp/splunk.lic -v `pwd`/support/test-data.json:/tmp/test-data.json -v `pwd`/support/test-data-large.json:/tmp/test-data-large.json splunk/splunk:latest'
     echo "****** Starting Elastic via Docker ******"
     bash -c 'docker run -d -it --name elastic_test -e node.name=es01 -e cluster.initial_master_nodes=es01 -e xpack.license.self_generated.type=trial -e xpack.security.enabled=true -e xpack.security.http.ssl.enabled=true -e xpack.security.http.ssl.key=/usr/share/elasticsearch/config/certificates/elastic_test/elastic_test.key -e xpack.security.http.ssl.certificate_authorities=/usr/share/elasticsearch/config/certificates/ca/ca.crt -e xpack.security.http.ssl.certificate=/usr/share/elasticsearch/config/certificates/elastic_test/elastic_test.crt -v `pwd`/support/certs:/usr/share/elasticsearch/config/certificates -p 9200:9200 docker.elastic.co/elasticsearch/elasticsearch:7.6.2'
     echo "****** Sleeping to allow containers to start ******"
     sleep 60
 
     echo "****** Loading Splunk data ******"
-    bash -c 'docker exec -it splunk_test sudo -u splunk cp /tmp/test-data.json /opt/splunk/var/spool/splunk'
+#    bash -c 'docker exec -it splunk_test sudo -u splunk cp /tmp/test-data.json /opt/splunk/var/spool/splunk'
+    bash -c 'docker exec -it splunk_test sudo /opt/splunk/bin/splunk list user -auth admin:testpass'
+    bash -c 'docker exec -it splunk_test sudo /opt/splunk/bin/splunk add index bigdata'
+    bash -c 'docker exec -it splunk_test sudo /opt/splunk/bin/splunk add oneshot /tmp/test-data.json -index main'
+    bash -c 'docker exec -it splunk_test sudo /opt/splunk/bin/splunk add oneshot /tmp/test-data-large.json -index bigdata'
+
     echo "****** Loading Elastic data ******"
     bash -c 'docker exec elastic_test bin/elasticsearch-setup-passwords auto --batch --url https://localhost:9200 | grep "PASSWORD elastic" | cut -d" " -f 4 > /tmp/elastic_pass.txt' 
     bash -c 'echo \{\"password\": \"testpass\"\} | curl -u elastic:`cat /tmp/elastic_pass.txt` --cacert support/certs/ca/ca.crt -H "Content-Type: application/json" -XPOST https://localhost:9200/_security/user/elastic/_password  --data-binary @-'


### PR DESCRIPTION
Because the Splunk API is so incredibly slow, this branch ditches it's `oneshot()` function in favor of the lower-level Splunk Jobs API.  Since we had to write our own results retrieval code, we used Python's built-in `multiprocessing` module to retrieve results in parallel.  The default is now to retrieve results with a single worker, which decreased total search time by about 45% while retrieving 1mil rows in testing.  

This PR also includes some code cleanups to improve the flow between `SplunkDF.search_df()` and `SplunkDF.search()` as well as adding both uniprocessing and multiprocessing versions of the same unit tests.