### PR TITLE
More time modifiers: hours and minutes

### DIFF
--- a/huntlib/splunk.py
+++ b/huntlib/splunk.py
@@ -66,10 +66,13 @@ class SplunkDF(object):
 
     splunk_conn = None # The connection to the Splunk server (Splunk client)
 
-    def __init__(self, host=None, username=None, password=None, token=None, port=8089):
+    def __init__(self, host=None, username=None, password=None, token=None, port=8089, conn=None):
         '''
         Create the SplunkDF object and login to the Splunk server.
         '''
+        if conn:
+            self.splunk_conn = conn
+            return
         try:
             if token:
                 self.splunk_conn = client.connect(
@@ -189,12 +192,11 @@ class SplunkDF(object):
                 query, like so: "| fields field1,field2,field3".  The default is '*',
                 meaning all fields.
         internal_fields: Control whether or not to return Splunk's internal fields.
-                If set to False, all fields with names beginning with an underscore 
+                If set to False, all fields with names beginning with an underscore
                 will be removed from the results.  If set to True, nothing will be removed.
                 If this is a string, treat it as a comma-separated list of fields to remove
                 from the results. Default is False.
         '''
-
         # Valid argument checking
         valid_args = [
             'spl', 
@@ -253,9 +255,8 @@ class SplunkDF(object):
             kwargs['search_args'] = dict()
         kwargs['search_args']["search_mode"] = kwargs['mode']
 
-        if (kwargs["days"] or kwargs["hours"] or kwargs["minutes"]) and not (
-             bool(kwargs["days"]) ^ bool(kwargs["hours"]) ^ bool(kwargs["minutes"])
-        ):
+        opts = sum(map(bool, [kwargs["days"], kwargs["hours"], kwargs["minutes"]]))
+        if opts > 1:
             raise ValueError("you must choose between days, hours or minutes")
 
         if kwargs['days']:

--- a/tests/test_splunk_df.py
+++ b/tests/test_splunk_df.py
@@ -2,6 +2,7 @@
 
 import os
 import unittest
+
 from multiprocessing import cpu_count
 from unittest import TestCase
 
@@ -344,3 +345,11 @@ class TestSplunkDF(TestCase):
             "val" in df.columns,
             "Column 'val' was not found in the search results."
         )
+
+    def test_too_many_time_modifiers(self):
+        '''
+        Do a basic search with more than one time modifier.
+        '''
+        with self.assertRaises(ValueError) as err:
+            self._splunk_conn.search(spl="search index=foobar hello", days=12, hours=23)
+        self.assertIn("between days", err)


### PR DESCRIPTION
👋 

Call me lazy but I kept wanting to have `minutes` and `hours` time modifiers arguments to `SplunkDF.search()` so here it is.

I also took the opportunity to create a new testing class dedicated to unit-testing with the use of dummy objects but I can remove it if you prefer!

What would you think of having a simple `./unit-tests.sh` doing:

```sh
#! /bin/sh

cd tests && 
  python -munittest -v test_splunk_df.UnitTestSplunk
```